### PR TITLE
fix bug

### DIFF
--- a/screencapture/src/main/java/com/shark/screencapture/ScreenCapture.java
+++ b/screencapture/src/main/java/com/shark/screencapture/ScreenCapture.java
@@ -385,7 +385,12 @@ public class ScreenCapture {
             if (this.mMediaCodec == null) {//防止退出nullPoint
                 break;
             }
-            int index = mMediaCodec.dequeueOutputBuffer(mBufferInfo, 10000);
+            int index = 0;
+            try {
+                index = this.mMediaCodec.dequeueOutputBuffer(this.mBufferInfo, 10000L);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             Log.d(TAG, "dequeue output buffer index=" + index);
             if (index == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {//后续输出格式变化
                 resetOutputFormat();
@@ -453,16 +458,16 @@ public class ScreenCapture {
         if (mMediaCodec != null) {
             mMediaCodec.stop();
             mMediaCodec.release();
-            mMediaCodec = null;
+            //mMediaCodec = null;
         }
         if (mVirtualDisplay != null) {
             mVirtualDisplay.release();
-            mVirtualDisplay = null;
+            //mVirtualDisplay = null;
         }
         if (mMuxer != null) {
             mMuxer.stop();
             mMuxer.release();
-            mMuxer = null;
+            //mMuxer = null;
         }
     }
 


### PR DESCRIPTION
由于循环录屏中，调用cleanup退出，mMediacodec释放资源，但本轮循未执行完成，对象状态异常导致的bug
2021-10-12 11:38:53 717    d    com.yys.monitor.ScreenCapture    ,record, release() 
2021-10-12 11:38:53 724    e    com.yys.utils.CrashHandler    =========java.lang.IllegalStateException
	at android.media.MediaCodec.native_dequeueOutputBuffer(Native Method)
	at android.media.MediaCodec.dequeueOutputBuffer(MediaCodec.java:2698)
	at com.yys.monitor.ScreenCapture.recordVirtualDisplay(ScreenCapture.java:385)
	at com.yys.monitor.ScreenCapture.lambda$startRecord$0(ScreenCapture.java:360)
	at com.yys.monitor.-$$Lambda$ScreenCapture$dgqDW8lr2mITEYv3l84i7RtgBOI.run(Unknown Source:2)
	at java.lang.Thread.run(Thread.java:764)